### PR TITLE
매수매도 비즈니스로직 및 해당 도메인들 구축

### DIFF
--- a/src/main/java/stock/mock_stock/common/StockNameCache.java
+++ b/src/main/java/stock/mock_stock/common/StockNameCache.java
@@ -30,7 +30,11 @@ public class StockNameCache {
         Map<String,StockInfoDto> allStockNames = stockRepository.findAllStockNames().stream()
                 .collect(Collectors.toMap(
                         StockNameProjection::getStckCode,
-                        projection -> StockInfoDto.builder().sid(projection.getSid()).stckName(projection.getStckName()).stckCode(projection.getStckCode()).build()
+                        projection -> StockInfoDto.builder()
+                                .sid(projection.getSid())
+                                .stckName(projection.getStckName())
+                                .stckCode(projection.getStckCode())
+                                .build()
                 ));
         stockNames.putAll(allStockNames);
 //        System.out.println("Stock names loaded: " + stockNames);

--- a/src/main/java/stock/mock_stock/config/SecurityConfig.java
+++ b/src/main/java/stock/mock_stock/config/SecurityConfig.java
@@ -3,7 +3,6 @@ package stock.mock_stock.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -27,7 +26,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // ✅ CORS 설정 추가
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 추가
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/stocks/search/history").authenticated()

--- a/src/main/java/stock/mock_stock/controller/AccountController.java
+++ b/src/main/java/stock/mock_stock/controller/AccountController.java
@@ -14,7 +14,6 @@ import stock.mock_stock.service.AccountService;
 
 
 @RestController
-
 @RequiredArgsConstructor
 public class AccountController {
 

--- a/src/main/java/stock/mock_stock/controller/OrderController.java
+++ b/src/main/java/stock/mock_stock/controller/OrderController.java
@@ -23,19 +23,17 @@ public class OrderController {
         System.out.println("OrderController.buyStock");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof Claims claims) {
-            System.out.println("inside.buyStock");
             Long userId = Long.valueOf(claims.getSubject());
+            orderService.processOrder(userId,
+                    orderRequestDto.getStckCode(),
+                    orderRequestDto.getQuantity(),
+                    orderRequestDto.getPrice(),
+                    orderRequestDto.getOrderType(),
+                    TradeActionType.BUY);
 
-             orderService.processOrder(userId,
-                     orderRequestDto.getStckCode(),
-                     orderRequestDto.getQuantity(),
-                     orderRequestDto.getPrice(),
-                     orderRequestDto.getOrderType(),
-                     TradeActionType.BUY);
 
-       return ResponseEntity.ok().build();
+            return ResponseEntity.ok().build();
         }
-        System.out.println("outside");
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated"); // 401 반환
     }
 

--- a/src/main/java/stock/mock_stock/controller/OrderController.java
+++ b/src/main/java/stock/mock_stock/controller/OrderController.java
@@ -1,0 +1,62 @@
+package stock.mock_stock.controller;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import stock.mock_stock.dto.OrderRequestDto;
+import stock.mock_stock.entity.TradeActionType;
+import stock.mock_stock.service.OrderService;
+
+@RestController
+@RequiredArgsConstructor
+public class OrderController {
+    private final OrderService orderService;
+    @PostMapping("/buy")
+    public ResponseEntity<?> buyStock(@RequestBody OrderRequestDto orderRequestDto){
+        System.out.println("OrderController.buyStock");
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof Claims claims) {
+            System.out.println("inside.buyStock");
+            Long userId = Long.valueOf(claims.getSubject());
+
+             orderService.processOrder(userId,
+                     orderRequestDto.getStckCode(),
+                     orderRequestDto.getQuantity(),
+                     orderRequestDto.getPrice(),
+                     orderRequestDto.getOrderType(),
+                     TradeActionType.BUY);
+
+       return ResponseEntity.ok().build();
+        }
+        System.out.println("outside");
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated"); // 401 반환
+    }
+
+    @PostMapping("/sell")
+    public ResponseEntity<?> sellStock(@RequestBody OrderRequestDto orderRequestDto){
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated() && authentication.getPrincipal() instanceof Claims claims) {
+            Long userId = Long.valueOf(claims.getSubject());
+
+            orderService.processOrder(userId,
+                    orderRequestDto.getStckCode(),
+                    orderRequestDto.getQuantity(),
+                    orderRequestDto.getPrice(),
+                    orderRequestDto.getOrderType(),
+                    TradeActionType.SELL);
+
+            return ResponseEntity.ok().build();
+        }
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "User is not authenticated"); // 401 반환
+    }
+
+
+}

--- a/src/main/java/stock/mock_stock/dto/OrderRequestDto.java
+++ b/src/main/java/stock/mock_stock/dto/OrderRequestDto.java
@@ -1,0 +1,16 @@
+package stock.mock_stock.dto;
+
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Data;
+import stock.mock_stock.entity.OrderType;
+
+@Data
+public class OrderRequestDto {
+
+    @Enumerated(EnumType.STRING)
+    private OrderType orderType;
+    private String stckCode;
+    private Long price;
+    private Long quantity;
+}

--- a/src/main/java/stock/mock_stock/entity/Account.java
+++ b/src/main/java/stock/mock_stock/entity/Account.java
@@ -17,8 +17,8 @@ public class Account {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long acid;
 
-    @OneToOne
-    @JoinColumn(name = "uid")  // User를 직접 참조하지 않고 uid로 관리
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uid", nullable = false)  // User를 직접 참조하지 않고 uid로 관리
     private User user;
 
     @Column(columnDefinition = "BIGINT DEFAULT 0")  // 테이블 만들때 DB에서 기본값 0 설정

--- a/src/main/java/stock/mock_stock/entity/AccountTransaction.java
+++ b/src/main/java/stock/mock_stock/entity/AccountTransaction.java
@@ -1,12 +1,17 @@
 package stock.mock_stock.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AccountTransaction {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/stock/mock_stock/entity/Order.java
+++ b/src/main/java/stock/mock_stock/entity/Order.java
@@ -1,0 +1,72 @@
+package stock.mock_stock.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class Order {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long oid;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "uid", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private String stockCode; // 주식 종목 코드
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderType orderType; // 매수(BUY) or 매도(SELL)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TradeActionType tradeAction; // 매수(BUY) or 매도(SELL)
+
+    @Column(nullable = false)
+    private Long stckOrdQty; // 주문 수량
+
+    @Column(nullable = false)
+    private Long stckOrdUnitPrice; // 주문 가격
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus orderStatus; // NEW, PENDING, COMPLETED, CANCELED
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();  // 엔티티가 수정될 때 변경 필요
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public Order(User user, String stockCode, OrderType orderType, TradeActionType tradeAction, Long stckOrdQty, Long stckOrdUnitPrice, OrderStatus orderStatus) {
+        this.user = user;
+        this.stockCode = stockCode;
+        this.orderType = orderType;
+        this.tradeAction = tradeAction;
+        this.stckOrdQty = stckOrdQty;
+        this.stckOrdUnitPrice = stckOrdUnitPrice;
+        this.orderStatus = orderStatus;
+    }
+}

--- a/src/main/java/stock/mock_stock/entity/Order.java
+++ b/src/main/java/stock/mock_stock/entity/Order.java
@@ -8,6 +8,8 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "orders")
 public class Order {
@@ -21,11 +23,11 @@ public class Order {
     private User user;
 
     @Column(nullable = false)
-    private String stockCode; // 주식 종목 코드
+    private String stckCode; // 주식 종목 코드
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private OrderType orderType; // 매수(BUY) or 매도(SELL)
+    private OrderType orderType; // 지정가(LIMIT) or 시장가(MARKET)
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -58,14 +60,4 @@ public class Order {
         this.updatedAt = LocalDateTime.now();
     }
 
-    @Builder
-    public Order(User user, String stockCode, OrderType orderType, TradeActionType tradeAction, Long stckOrdQty, Long stckOrdUnitPrice, OrderStatus orderStatus) {
-        this.user = user;
-        this.stockCode = stockCode;
-        this.orderType = orderType;
-        this.tradeAction = tradeAction;
-        this.stckOrdQty = stckOrdQty;
-        this.stckOrdUnitPrice = stckOrdUnitPrice;
-        this.orderStatus = orderStatus;
-    }
 }

--- a/src/main/java/stock/mock_stock/entity/Order.java
+++ b/src/main/java/stock/mock_stock/entity/Order.java
@@ -3,7 +3,6 @@ package stock.mock_stock.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
@@ -40,7 +39,7 @@ public class Order {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private OrderStatus orderStatus; // NEW, PENDING, COMPLETED, CANCELED
+    private OrderStatus orderStatus; // PENDING, FILLED, CANCELED
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/stock/mock_stock/entity/OrderStatus.java
+++ b/src/main/java/stock/mock_stock/entity/OrderStatus.java
@@ -1,0 +1,7 @@
+package stock.mock_stock.entity;
+
+public enum OrderStatus {
+    PENDING,
+    FILLED,
+    CANCELLED,
+}

--- a/src/main/java/stock/mock_stock/entity/OrderStatus.java
+++ b/src/main/java/stock/mock_stock/entity/OrderStatus.java
@@ -3,5 +3,5 @@ package stock.mock_stock.entity;
 public enum OrderStatus {
     PENDING,
     FILLED,
-    CANCELLED,
+    CANCELED,
 }

--- a/src/main/java/stock/mock_stock/entity/OrderTransaction.java
+++ b/src/main/java/stock/mock_stock/entity/OrderTransaction.java
@@ -1,6 +1,7 @@
 package stock.mock_stock.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -10,8 +11,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderTransaction {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,9 +21,6 @@ public class OrderTransaction {
     @OneToOne
     @JoinColumn(name = "oid", nullable = false)
     private Order order;
-
-    @Column(nullable = false)
-    private OrderStatus orderStatus;
 
     @Column(nullable = false)
     private Long stckExecUnitPrice;

--- a/src/main/java/stock/mock_stock/entity/OrderTransaction.java
+++ b/src/main/java/stock/mock_stock/entity/OrderTransaction.java
@@ -18,7 +18,7 @@ public class OrderTransaction {
     private Long otid;
 
     @OneToOne
-    @JoinColumn(name = "oid")
+    @JoinColumn(name = "oid", nullable = false)
     private Order order;
 
     @Column(nullable = false)

--- a/src/main/java/stock/mock_stock/entity/OrderTransaction.java
+++ b/src/main/java/stock/mock_stock/entity/OrderTransaction.java
@@ -1,0 +1,41 @@
+package stock.mock_stock.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderTransaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long otid;
+
+    @OneToOne
+    @JoinColumn(name = "oid")
+    private Order order;
+
+    @Column(nullable = false)
+    private OrderStatus orderStatus;
+
+    @Column(nullable = false)
+    private Long stckExecUnitPrice;
+
+    @Column(nullable = false)
+    private Long stckExecQty;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/stock/mock_stock/entity/OrderType.java
+++ b/src/main/java/stock/mock_stock/entity/OrderType.java
@@ -1,0 +1,6 @@
+package stock.mock_stock.entity;
+
+public enum OrderType {
+    LIMIT,
+    MARKET
+}

--- a/src/main/java/stock/mock_stock/entity/Portfolio.java
+++ b/src/main/java/stock/mock_stock/entity/Portfolio.java
@@ -1,0 +1,52 @@
+package stock.mock_stock.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+public class Portfolio {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pfid;
+
+    @ManyToOne
+    @JoinColumn(name = "uid", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 12)
+    private String stckCode;
+
+    @Column(nullable = false)
+    private Long stckQty;
+
+    @Column(nullable = false)
+    private Long totalInitialAmount;
+
+    @Column(nullable = false)
+    private BigDecimal avgPurchasePrice;
+
+
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();  // 엔티티가 수정될 때 변경 필요
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/stock/mock_stock/entity/Portfolio.java
+++ b/src/main/java/stock/mock_stock/entity/Portfolio.java
@@ -1,8 +1,7 @@
 package stock.mock_stock.entity;
 
 import jakarta.persistence.*;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -10,6 +9,8 @@ import java.time.LocalDateTime;
 @Entity
 @Data
 @Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Portfolio {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,9 +25,6 @@ public class Portfolio {
 
     @Column(nullable = false)
     private Long stckQty;
-
-    @Column(nullable = false)
-    private Long totalInitialAmount;
 
     @Column(nullable = false)
     private BigDecimal avgPurchasePrice;

--- a/src/main/java/stock/mock_stock/entity/TradeActionType.java
+++ b/src/main/java/stock/mock_stock/entity/TradeActionType.java
@@ -1,0 +1,6 @@
+package stock.mock_stock.entity;
+
+public enum TradeActionType {
+    BUY,
+    SELL
+}

--- a/src/main/java/stock/mock_stock/repository/AccountRepository.java
+++ b/src/main/java/stock/mock_stock/repository/AccountRepository.java
@@ -1,6 +1,8 @@
 package stock.mock_stock.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import stock.mock_stock.entity.Account;
 import stock.mock_stock.entity.User;
 
@@ -8,5 +10,8 @@ import java.util.Optional;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
     Optional<Account> findByUserUid(Long uid);
+
+    @Query("SELECT a FROM Account a JOIN FETCH a.user WHERE a.user.uid = :uid")
+    Optional<Account> findWithUserByUid(@Param("uid") Long uid); // TODO: 이렇게 JOIN FETCH를 별도로 추가해서 Account 는 LAZY LOADING으로 하면 하고안하고 차이를 알고 성능 최적화를 어떻게했는지 알기위해 테스트 필요,
 
 }

--- a/src/main/java/stock/mock_stock/repository/OrderRepository.java
+++ b/src/main/java/stock/mock_stock/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package stock.mock_stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import stock.mock_stock.entity.Order;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/stock/mock_stock/repository/OrderTransactionRepository.java
+++ b/src/main/java/stock/mock_stock/repository/OrderTransactionRepository.java
@@ -1,0 +1,7 @@
+package stock.mock_stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import stock.mock_stock.entity.OrderTransaction;
+
+public interface OrderTransactionRepository extends JpaRepository<OrderTransaction, Long> {
+}

--- a/src/main/java/stock/mock_stock/repository/PortfolioRepository.java
+++ b/src/main/java/stock/mock_stock/repository/PortfolioRepository.java
@@ -1,0 +1,11 @@
+package stock.mock_stock.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import stock.mock_stock.entity.Portfolio;
+import stock.mock_stock.entity.User;
+
+import java.util.Optional;
+
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+    public Optional<Portfolio> findByUserAndStckCode(User user, String stckCode);
+}

--- a/src/main/java/stock/mock_stock/service/AccountService.java
+++ b/src/main/java/stock/mock_stock/service/AccountService.java
@@ -1,9 +1,11 @@
 package stock.mock_stock.service;
 
 import stock.mock_stock.dto.AccountResponseDto;
+import stock.mock_stock.entity.Account;
 import stock.mock_stock.entity.TransactionType;
 
 public interface AccountService {
     public AccountResponseDto getAccount(Long uid);
     public void processTransaction(Long uid, Long amount);
+    public void recordTransaction(Account account, Long amount, TransactionType type);
 }

--- a/src/main/java/stock/mock_stock/service/AccountServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/AccountServiceImpl.java
@@ -63,7 +63,17 @@ public class AccountServiceImpl implements AccountService{
 
         //잔액 업데이트
         account.setBalance(account.getBalance() + amount);
-        accountRepository.save(account);
+//        accountRepository.save(account); // NOTE: Dirty Checking wjrdyd
 
+    }
+
+    @Override
+    public void recordTransaction(Account account, Long amount, TransactionType type) {
+        AccountTransaction accountTransaction = AccountTransaction.builder()
+                .account(account)
+                .amount(amount)
+                .transactionType(type)
+                .build();
+        transitionRepository.save(accountTransaction);
     }
 }

--- a/src/main/java/stock/mock_stock/service/AccountServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/AccountServiceImpl.java
@@ -24,7 +24,7 @@ public class AccountServiceImpl implements AccountService{
     @Override
     public AccountResponseDto getAccount(Long uid) {
 
-        Account account = accountRepository.findByUserUid(uid)
+        Account account = accountRepository.findWithUserByUid(uid)
                 .orElseThrow(()-> new EntityNotFoundException("account with id "+ uid+ " not found"));
 
         if (!account.getUser().getUid().equals(uid)) {

--- a/src/main/java/stock/mock_stock/service/KISApiServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/KISApiServiceImpl.java
@@ -35,7 +35,8 @@ public class KISApiServiceImpl implements KISApiService{
     private final TokenStorage tokenStorage;
     private final KISWebSocketClient kisWebSocketClient;
     private final StockValidator stockValidator;
-
+    private final Object historyLock = new Object();
+    private final Object priceLock = new Object();
     @Override
     public StockInfoOutput getDomesticStockInfo(String fidCondMrktDivCode, String fidInputIscd) {
         // URL 구성
@@ -59,9 +60,10 @@ public class KISApiServiceImpl implements KISApiService{
         ResponseEntity<StockInfoOutput> response;
         try{
         // API 호출
-        response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class); // 한투에서 output상위 속성이있어 상위클래스 StockInfoOuput으로 매핑되도록 설정
-//        System.out.println("response = " + response.getBody());
-
+            synchronized (priceLock) {
+                response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class);
+                Thread.sleep(500);
+            }
         } catch (HttpServerErrorException e) {
             // 예외로부터 응답 본문(JSON)을 추출
             String responseBody = e.getResponseBodyAsString();
@@ -86,6 +88,9 @@ public class KISApiServiceImpl implements KISApiService{
             } catch (Exception ex) {
                 System.err.println("JSON 파싱 오류: " + ex.getMessage());
             }
+            return null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             return null;
         }
         return response.getBody();
@@ -144,18 +149,17 @@ public class KISApiServiceImpl implements KISApiService{
 
              try{
                  // API 호출
-                 response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class); // 한투에서 output상위 속성이있어 상위클래스 StockInfoOuput으로 매핑되도록 설정
-                 allData.addAll(response.getBody().getStockKisHistoryDto());
+                 synchronized (historyLock) {
+                     //  동기화된 블록 내부에서 호출
+                     response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class);
+                     allData.addAll(response.getBody().getStockKisHistoryDto());
 
-                 String lastHour = allData.get(allData.size()-1).getStckCntgHour();
+                     String lastHour = allData.get(allData.size() - 1).getStckCntgHour();
 
-                 if(lastHour.compareTo("090000") <= 0){
-                     break;
-                 } else{
-                     toDateTime = lastHour;
+                     if (lastHour.compareTo("090000") <= 0) break;
+                     else toDateTime = lastHour;
 
-                     Thread.sleep(500); // NOTE: 0.5초 대기, 이유: 한국투자증권 초당 요청건수 한계가있어서 어느정도 텀을 주기위해, 0.4초로하면 될때도있고 통과못할때도있기때문에 0.5로
-                     // TODO: 한국투자에 공통키로 서버쪽에서 유저가 요청하는만큼 요청해도 초당 요청한계가있어서 에러가 발생 만약 10명만 요청을 한번에 보내도 해당 리밋초과이기 떄문 이에 대한 해결책 강구필요
+                     Thread.sleep(500); // 요청 간 텀
                  }
              } catch (HttpServerErrorException e) {
                  // 예외로부터 응답 본문(JSON)을 추출
@@ -208,9 +212,10 @@ public class KISApiServiceImpl implements KISApiService{
             entity = new HttpEntity<>(headers);
 
             try{
-                // API 호출
-                response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class); // 한투에서 output상위 속성이있어 상위클래스 StockInfoOuput으로 매핑되도록 설정
-
+                synchronized (historyLock) {
+                    response = restTemplate.exchange(url, HttpMethod.GET, entity, StockInfoOutput.class);
+                    Thread.sleep(500); // 요청 간 딜레이 보장
+                }
             } catch (HttpServerErrorException e) {
                 // 예외로부터 응답 본문(JSON)을 추출
                 String responseBody = e.getResponseBodyAsString();
@@ -236,6 +241,8 @@ public class KISApiServiceImpl implements KISApiService{
                     System.err.println("JSON 파싱 오류: " + ex.getMessage());
                 }
                 return null;
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/stock/mock_stock/service/OrderService.java
+++ b/src/main/java/stock/mock_stock/service/OrderService.java
@@ -1,0 +1,10 @@
+package stock.mock_stock.service;
+
+import stock.mock_stock.entity.OrderType;
+import stock.mock_stock.entity.TradeActionType;
+
+public interface OrderService {
+
+    public void processOrder(Long userId, String stockCode, Long quantity, Long price, OrderType orderType, TradeActionType tradeActionType);
+
+}

--- a/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
@@ -1,0 +1,142 @@
+package stock.mock_stock.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import stock.mock_stock.entity.*;
+import stock.mock_stock.repository.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+    private final OrderRepository orderRepository;
+    private final PortfolioRepository portfolioRepository;
+    private final AccountRepository accountRepository;
+    private final OrderTransactionRepository orderTransactionRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void processOrder(Long userId, String stockCode, Long quantity, Long price, OrderType orderType, TradeActionType tradeActionType) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        // NOTE: 주문 기록
+        Order order = Order.builder()
+                .user(user)
+                .stockCode(stockCode)
+                .stckOrdQty(quantity)
+                .stckOrdUnitPrice(price)
+                .orderType(orderType)
+                .orderStatus(OrderStatus.PENDING) // 주문 초기 상태
+                .build();
+        orderRepository.save(order); // 새 엔티티는 INSERT 실행 필요
+
+        Account account = accountRepository.findByUserUid(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Account not found"));
+
+        // NOTE: 계좌 잔액 차감 (매수 시)
+        if (tradeActionType == TradeActionType.BUY) {
+            BigDecimal totalCost = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
+
+            if (BigDecimal.valueOf(account.getBalance()).compareTo(totalCost) < 0) {
+                throw new IllegalArgumentException("잔액 부족");
+            }
+            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).subtract(totalCost);
+            account.setBalance(updatedBalance.longValue()); // 이때 Dirty checking 적용됨, @Transactional 있다는 가정하에
+//            accountRepository.save(account); // Dirty checking 으로 필요없음
+
+            // NOTE: Portfolio 업데이트
+            updatePortfolio(user, stockCode, quantity, price, tradeActionType);
+
+        }  else if (tradeActionType == TradeActionType.SELL) {
+            BigDecimal totalRevenue = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
+            // NOTE: Portfolio 업데이트
+            updatePortfolio(user, stockCode, quantity, price, tradeActionType);
+            // NOTE: 계좌에 금액 추가 (매도 후 잔액 증가)
+            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).add(totalRevenue);
+            account.setBalance(updatedBalance.longValue());
+        }
+
+
+
+        // NOTE: 주문 체결 완료 처리
+        order.setOrderStatus(OrderStatus.FILLED); // 이때 Dirty checking 적용됨, @Transactional 있다는 가정하에
+//        orderRepository.save(order);  // Dirty checking 으로 필요없음
+
+        // NOTE: `OrderTransaction` 저장
+        saveOrderTransaction(order);
+    }
+
+    private void saveOrderTransaction(Order order) {
+        OrderTransaction transaction = OrderTransaction.builder()
+                .order(order)
+                .stckExecUnitPrice(order.getStckOrdUnitPrice()) // NOTE: 체결 가격
+                .stckExecQty(order.getStckOrdQty()) // NOTE: 체결 수량
+                .build();
+
+        orderTransactionRepository.save(transaction); // NOTE: 새 엔티티는 INSERT 실행 필요
+    }
+
+    /**
+     *  `Portfolio` 업데이트 (보유 주식 정보 반영)
+     */
+    private void updatePortfolio(User user, String stockCode, Long quantity, Long price, TradeActionType tradeActionType) {
+        Optional<Portfolio> existingPortfolio = portfolioRepository.findByUserAndStckCode(user, stockCode);
+
+        if (tradeActionType == TradeActionType.BUY) {
+            if (existingPortfolio.isPresent()) {
+                Portfolio portfolio = existingPortfolio.get();
+                Long newStockQty = portfolio.getStckQty() + quantity;
+                BigDecimal newAvgPrice = calculateNewAveragePrice(portfolio, quantity, price);
+                portfolio.setStckCode(stockCode);
+                portfolio.setStckQty(newStockQty);
+                portfolio.setAvgPurchasePrice(newAvgPrice);
+//                portfolioRepository.save(portfolio); // NOTE: Dirty checking 으로 필요없음
+            } else {
+
+                Portfolio newPortfolio = Portfolio.builder()
+                        .user(user)
+                        .stckCode(stockCode)
+                        .stckQty(quantity)
+                        .avgPurchasePrice(BigDecimal.valueOf(price))
+                        .build();
+                portfolioRepository.save(newPortfolio);  // NOTE: 새 엔티티는 INSERT 실행 필요
+            }
+        } else if (tradeActionType == TradeActionType.SELL) {
+            if (existingPortfolio.isPresent()) {
+                Portfolio portfolio = existingPortfolio.get();
+                if (portfolio.getStckQty() < quantity) {
+                    throw new IllegalArgumentException("Not enough stocks to sell");
+                }
+
+                //  보유 주식 수량 감소
+                portfolio.setStckQty(portfolio.getStckQty() - quantity);
+
+                //  보유 주식이 0개가 되면 삭제
+                if (portfolio.getStckQty() == 0) {
+                    portfolioRepository.delete(portfolio);
+                }
+            } else {
+                throw new IllegalArgumentException("No stocks available to sell");
+            }
+        }
+    }
+
+    /**
+     *  평균 매입가 계산 메서드
+     */
+    private BigDecimal calculateNewAveragePrice(Portfolio portfolio, Long newQuantity, Long newPrice) {
+        Long currentQty = portfolio.getStckQty();
+        BigDecimal currentTotalPrice = portfolio.getAvgPurchasePrice().multiply(BigDecimal.valueOf(currentQty));
+        BigDecimal newTotalPrice = BigDecimal.valueOf(newPrice).multiply(BigDecimal.valueOf(newQuantity));
+        BigDecimal updatedQty = BigDecimal.valueOf(currentQty).add(BigDecimal.valueOf(newQuantity));
+        return (currentTotalPrice.add(newTotalPrice)).divide(updatedQty, 2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import stock.mock_stock.dto.StockInfoDto;
 import stock.mock_stock.entity.*;
 import stock.mock_stock.repository.*;
 
@@ -21,12 +22,18 @@ public class OrderServiceImpl implements OrderService {
     private final AccountRepository accountRepository;
     private final OrderTransactionRepository orderTransactionRepository;
     private final UserRepository userRepository;
+    private final StockDetailService stockDetailService;
 
     @Override
     @Transactional
     public void processOrder(Long userId, String stockCode, Long orderQuantity, Long unitPrice, OrderType orderType, TradeActionType tradeActionType) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
+
+        // NOTE: 해당 시세 조회
+        if(orderType == OrderType.MARKET){
+                unitPrice = stockDetailService.getStockInfo(stockCode).getStckCurPrice();
+        }
 
         // NOTE: 주문 기록
         Order order = Order.builder()

--- a/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
@@ -19,23 +19,23 @@ public class OrderServiceImpl implements OrderService {
     private final OrderRepository orderRepository;
     private final PortfolioRepository portfolioRepository;
     private final AccountRepository accountRepository;
-    private final TransitionRepository transitionRepository;
     private final OrderTransactionRepository orderTransactionRepository;
     private final UserRepository userRepository;
 
     @Override
     @Transactional
-    public void processOrder(Long userId, String stockCode, Long quantity, Long price, OrderType orderType, TradeActionType tradeActionType) {
+    public void processOrder(Long userId, String stockCode, Long orderQuantity, Long unitPrice, OrderType orderType, TradeActionType tradeActionType) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
         // NOTE: 주문 기록
         Order order = Order.builder()
                 .user(user)
-                .stockCode(stockCode)
-                .stckOrdQty(quantity)
-                .stckOrdUnitPrice(price)
+                .stckCode(stockCode)
+                .stckOrdQty(orderQuantity)
+                .stckOrdUnitPrice(unitPrice)
                 .orderType(orderType)
+                .tradeAction(tradeActionType)
                 .orderStatus(OrderStatus.PENDING) // 주문 초기 상태
                 .build();
         orderRepository.save(order); // 새 엔티티는 INSERT 실행 필요
@@ -45,7 +45,7 @@ public class OrderServiceImpl implements OrderService {
 
         // NOTE: 계좌 잔액 차감 (매수 시)
         if (tradeActionType == TradeActionType.BUY) {
-            BigDecimal totalCost = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
+            BigDecimal totalCost = BigDecimal.valueOf(unitPrice).multiply(BigDecimal.valueOf(orderQuantity));
 
             if (BigDecimal.valueOf(account.getBalance()).compareTo(totalCost) < 0) {
                 throw new IllegalArgumentException("잔액 부족");
@@ -57,26 +57,21 @@ public class OrderServiceImpl implements OrderService {
             accountService.recordTransaction(account, -totalCost.longValue(), TransactionType.WITHDRAWAL);
 
             // NOTE: Portfolio 업데이트
-            updatePortfolio(user, stockCode, quantity, price, tradeActionType);
+            updatePortfolio(user, stockCode, orderQuantity, unitPrice, tradeActionType);
 
-        }  else if (tradeActionType == TradeActionType.SELL) {
-            BigDecimal totalCost = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
+        } else if (tradeActionType == TradeActionType.SELL) {
+            BigDecimal totalAmount = BigDecimal.valueOf(unitPrice).multiply(BigDecimal.valueOf(orderQuantity));
             // NOTE: Portfolio 업데이트
-            updatePortfolio(user, stockCode, quantity, price, tradeActionType);
+            updatePortfolio(user, stockCode, orderQuantity, unitPrice, tradeActionType);
             // NOTE: 계좌에 금액 추가 (매도 후 잔액 증가)
-            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).add(totalCost);
-            account.setBalance(totalCost.longValue());
-            accountService.recordTransaction(account, updatedBalance.longValue(), TransactionType.DEPOSIT);
+            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).add(totalAmount);
+            account.setBalance(updatedBalance.longValue());
+            accountService.recordTransaction(account, totalAmount.longValue(), TransactionType.DEPOSIT);
         }
 
-
-
-        // NOTE: 주문 체결 완료 처리
-        order.setOrderStatus(OrderStatus.FILLED); // 이때 Dirty checking 적용됨, @Transactional 있다는 가정하에
+        order.setOrderStatus(OrderStatus.FILLED); // NOTE: 주문 체결 완료 처리, 이때 Dirty checking 적용됨, @Transactional 있다는 가정하에
 //        orderRepository.save(order);  // Dirty checking 으로 필요없음
-
-        // NOTE: `OrderTransaction` 저장
-        saveOrderTransaction(order);
+        saveOrderTransaction(order);    // NOTE: 체결완료시 주문체결 저장
     }
 
     private void saveOrderTransaction(Order order) {
@@ -93,14 +88,14 @@ public class OrderServiceImpl implements OrderService {
     /**
      *  `Portfolio` 업데이트 (보유 주식 정보 반영), 오직 주문 처리의 일부, 재사용성 아직없음, 추후 필요시 분리
      */
-    private void updatePortfolio(User user, String stockCode, Long quantity, Long price, TradeActionType tradeActionType) {
+    private void updatePortfolio(User user, String stockCode, Long orderQuantity, Long unitPrice, TradeActionType tradeActionType) {
         Optional<Portfolio> existingPortfolio = portfolioRepository.findByUserAndStckCode(user, stockCode);
 
         if (tradeActionType == TradeActionType.BUY) {
             if (existingPortfolio.isPresent()) {
                 Portfolio portfolio = existingPortfolio.get();
-                Long newStockQty = portfolio.getStckQty() + quantity;
-                BigDecimal newAvgPrice = calculateNewAveragePrice(portfolio, quantity, price);
+                Long newStockQty = portfolio.getStckQty() + orderQuantity;
+                BigDecimal newAvgPrice = calculateNewAveragePrice(portfolio, orderQuantity, unitPrice);
                 portfolio.setStckCode(stockCode);
                 portfolio.setStckQty(newStockQty);
                 portfolio.setAvgPurchasePrice(newAvgPrice);
@@ -110,20 +105,20 @@ public class OrderServiceImpl implements OrderService {
                 Portfolio newPortfolio = Portfolio.builder()
                         .user(user)
                         .stckCode(stockCode)
-                        .stckQty(quantity)
-                        .avgPurchasePrice(BigDecimal.valueOf(price))
+                        .stckQty(orderQuantity)
+                        .avgPurchasePrice(BigDecimal.valueOf(unitPrice))
                         .build();
                 portfolioRepository.save(newPortfolio);  // NOTE: 새 엔티티는 INSERT 실행 필요
             }
         } else if (tradeActionType == TradeActionType.SELL) {
             if (existingPortfolio.isPresent()) {
                 Portfolio portfolio = existingPortfolio.get();
-                if (portfolio.getStckQty() < quantity) {
+                if (portfolio.getStckQty() < orderQuantity) {
                     throw new IllegalArgumentException("Not enough stocks to sell");
                 }
 
                 //  보유 주식 수량 감소
-                portfolio.setStckQty(portfolio.getStckQty() - quantity);
+                portfolio.setStckQty(portfolio.getStckQty() - orderQuantity);
 
                 //  보유 주식이 0개가 되면 삭제
                 if (portfolio.getStckQty() == 0) {

--- a/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/OrderServiceImpl.java
@@ -15,9 +15,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class OrderServiceImpl implements OrderService {
 
+    private final AccountService accountService;
     private final OrderRepository orderRepository;
     private final PortfolioRepository portfolioRepository;
     private final AccountRepository accountRepository;
+    private final TransitionRepository transitionRepository;
     private final OrderTransactionRepository orderTransactionRepository;
     private final UserRepository userRepository;
 
@@ -52,16 +54,19 @@ public class OrderServiceImpl implements OrderService {
             account.setBalance(updatedBalance.longValue()); // 이때 Dirty checking 적용됨, @Transactional 있다는 가정하에
 //            accountRepository.save(account); // Dirty checking 으로 필요없음
 
+            accountService.recordTransaction(account, -totalCost.longValue(), TransactionType.WITHDRAWAL);
+
             // NOTE: Portfolio 업데이트
             updatePortfolio(user, stockCode, quantity, price, tradeActionType);
 
         }  else if (tradeActionType == TradeActionType.SELL) {
-            BigDecimal totalRevenue = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
+            BigDecimal totalCost = BigDecimal.valueOf(price).multiply(BigDecimal.valueOf(quantity));
             // NOTE: Portfolio 업데이트
             updatePortfolio(user, stockCode, quantity, price, tradeActionType);
             // NOTE: 계좌에 금액 추가 (매도 후 잔액 증가)
-            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).add(totalRevenue);
-            account.setBalance(updatedBalance.longValue());
+            BigDecimal updatedBalance = BigDecimal.valueOf(account.getBalance()).add(totalCost);
+            account.setBalance(totalCost.longValue());
+            accountService.recordTransaction(account, updatedBalance.longValue(), TransactionType.DEPOSIT);
         }
 
 
@@ -84,8 +89,9 @@ public class OrderServiceImpl implements OrderService {
         orderTransactionRepository.save(transaction); // NOTE: 새 엔티티는 INSERT 실행 필요
     }
 
+
     /**
-     *  `Portfolio` 업데이트 (보유 주식 정보 반영)
+     *  `Portfolio` 업데이트 (보유 주식 정보 반영), 오직 주문 처리의 일부, 재사용성 아직없음, 추후 필요시 분리
      */
     private void updatePortfolio(User user, String stockCode, Long quantity, Long price, TradeActionType tradeActionType) {
         Optional<Portfolio> existingPortfolio = portfolioRepository.findByUserAndStckCode(user, stockCode);

--- a/src/main/java/stock/mock_stock/service/StockDetailServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/StockDetailServiceImpl.java
@@ -46,11 +46,6 @@ public class StockDetailServiceImpl implements StockDetailService {
     @Override
     public List<StockKisHistoryDto> getStockHistory(String stckCode, LocalDate fromDate, LocalDate toDate, String interval) throws InterruptedException {
 //        Stock stock = stockValidator.getStock(stckCode);
-        synchronized (apiLock){ // NOTE: 배치, 캐싱으로도 파라미터가 다를땐 처리할수없기떄문에 동기화로 단일 쓰레드로 요청사이에 0.5초를 주워 에러발생하지않도록 처리, 하지만 100명이 동시에 요청했다면 0.5*100 =50초 딜레이 발생
-            // API 호출 전 대기 시간 추가 (기존 호출과 겹치지 않도록)
-            Thread.sleep(500);
             return kisApiService.getStockHistoryInfo("J", stckCode, fromDate, toDate, interval);
-        }
-
     }
 }

--- a/src/main/java/stock/mock_stock/service/WatchlistServiceImpl.java
+++ b/src/main/java/stock/mock_stock/service/WatchlistServiceImpl.java
@@ -32,14 +32,7 @@ public class WatchlistServiceImpl implements WatchlistService{
     public List<WatchlistResponseDto> getWatchList(Long uid)  {
         List<Watchlist> watchlist = watchlistRepository.findByUserUid(uid);
         return watchlist.stream().map(item -> {
-            synchronized (apiLock){ // NOTE: 배치, 캐싱으로도 파라미터가 다를땐 처리할수없기떄문에 동기화로 단일 쓰레드로 요청사이에 0.5초를 주워 에러발생하지않도록 처리, 하지만 100명이 동시에 요청했다면 0.5*100 =50초 딜레이 발생
-                // API 호출 전 대기 시간 추가 (기존 호출과 겹치지 않도록)
             StockInfoDto stockData = stockDetailService.getStockInfo(item.getStckCode());
-                try {
-                    Thread.sleep(500); // 초당요청건수땜에 추가
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
                 return WatchlistResponseDto.builder()
                     .wid(item.getWid())
                     .sid(item.getSid())
@@ -49,7 +42,7 @@ public class WatchlistServiceImpl implements WatchlistService{
                     .stckPrevClsDiffPrice(stockData.getStckPrevClsDiffPrice())
                     .stckPrevClsDiffPercent(stockData.getStckPrevClsDiffPercent())
                     .build();
-        }}).collect(Collectors.toList());
+        }).collect(Collectors.toList());
 
 
     }


### PR DESCRIPTION
## 배경

## 작업 내용
주문, 주문기록, 계좌, 계좌기록, 포트폴리오 도메인 구축 및 매수매도 비즈니스로직 구현
기존 한투 api요청 동시성관련 synchronized, lock + sleep위치 비즈니스안 한투 api호출하는부분에만 적용하도록 수정 직렬화
## 테스트 방법

## 리뷰 노트

## 스크린샷

| Before | After |
|:---:|:---:|
| 사진1 | 사진2 |
